### PR TITLE
Add cmake and pkg support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,138 +34,6 @@ enable_cxx(20)
 
 add_library(qrcode INTERFACE)
 
-target_sources(qrcode INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/cx/vector.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/result.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/svg.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/symbol.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/bit_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/block_info.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/byte_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/code_block.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/code_capacity.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/codeword_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/error_correction_code.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/error_correction_polynomial.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/extended_remainder.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/format_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/gf2p8.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/lfsr.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/padding_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/polynomial.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/polynomial_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/sequence.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/sequence_description.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/sequence_permutation.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/code/sequence_view.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/alphanumeric.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/alphanumeric_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/alphanumeric_encoder.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/bit_stream.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/byte.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/byte_encoder.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/encoders.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/indicator.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/kanji.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/kanji_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/kanji_encoder.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/numeric.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/numeric_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/numeric_encoder.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/best_fit/best_encoder.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/best_fit/data_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/best_fit/data_length.h
-    
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/optimizer/data_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/optimizer/data_length.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/optimizer/dispatch_mode.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/optimizer/mode.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/optimizer/optimize.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/data/optimizer/optimizer_state.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/apply_mask.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/cartesian_product_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/data_masking.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/dimension.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/element_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/horizontal_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/make_matrix.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/matrix.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/module.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/module_traits.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/occupied_columns.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/place_data.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/position.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/separator_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/skip_column_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/timing_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/vertical_view.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/structure/zigzag_view.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/eci/assignment_number.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/eci/message_header.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/eci/view.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/qr.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/adjacent_score.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/alignment_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/best_version.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/raw_code.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/code_bits.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/code_capacity.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/dark_module_score.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/data_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/data_length.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/symbol_designator.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/encoders.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/error_correction.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/finalize_symbol.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/finder_like_score.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/finder_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/format_information.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/generator_degree.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/mask_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/optimized_data_encoding.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/optimized_data_length.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/penalty_score.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/penalty_weight.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/same_color_score.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/separator_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/symbol_version.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/timing_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/total_data_bits.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/total_blocks.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/version_category.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qr/version_information.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/micro_qr.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/best_version.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/raw_code.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/code_bits.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/code_capacity.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/symbol_designator.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/encoders.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/error_correction.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/finalize_symbol.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/finder_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/format_information.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/generator_degree.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/mask_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/penalty_score.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/separator_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/symbol_number.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/symbol_version.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/timing_pattern.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/micro_qr/total_data_bits.h
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/qrcode/qrcode.h
-)
-
-target_include_directories(qrcode INTERFACE "include")
 target_link_libraries(qrcode INTERFACE $<$<PLATFORM_ID:Linux>:stdc++ m>)
 target_link_libraries(qrcode INTERFACE $<$<PLATFORM_ID:Darwin>:stdc++ m>)
 target_compile_options(qrcode INTERFACE $<$<PLATFORM_ID:Windows>:/std:c++latest>)
@@ -173,3 +41,41 @@ target_compile_options(qrcode INTERFACE $<$<PLATFORM_ID:Windows>:/std:c++latest>
 if (QRCODE_TESTS_ENABLED)
     add_subdirectory(test)
 endif ()
+
+
+# Installation rules
+target_include_directories(qrcode INTERFACE 
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/libqrcodeConfigVersion.cmake"
+    VERSION 0.1
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(TARGETS qrcode
+    EXPORT qrcodeTargets
+    LIBRARY DESTINATION lib COMPONENT Runtime
+    ARCHIVE DESTINATION lib COMPONENT Development
+    RUNTIME DESTINATION bin COMPONENT Runtime
+    PUBLIC_HEADER DESTINATION include COMPONENT Development
+    BUNDLE DESTINATION bin COMPONENT Runtime
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/cmake/libqrcodeConfig.cmake.in"
+    "${PROJECT_BINARY_DIR}/libqrcodeConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/qrcode
+)
+
+install(EXPORT qrcodeTargets DESTINATION lib/cmake/qrcode)
+install(FILES "${PROJECT_BINARY_DIR}/libqrcodeConfigVersion.cmake"
+              "${PROJECT_BINARY_DIR}/libqrcodeConfig.cmake"
+        DESTINATION lib/cmake/qrcode)
+install(FILES "${PROJECT_SOURCE_DIR}/cmake/qrcode.pc.in"
+        DESTINATION lib/pkgconfig)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include/qrcode)

--- a/cmake/libqrcodeConfig.cmake.in
+++ b/cmake/libqrcodeConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/qrcode.pc.in
+++ b/cmake/qrcode.pc.in
@@ -1,0 +1,7 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: QR Code generation for Modern C++
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}

--- a/include/qrcode/code/byte_view.h
+++ b/include/qrcode/code/byte_view.h
@@ -31,6 +31,7 @@
 #include <concepts>
 #include <iterator>
 #include <optional>
+#include <limits>
 
 namespace qrcode::code::detail
 {


### PR DESCRIPTION
This MR will bring the possibility to run `cmake --install` to install the library system wide. It also installs .pc file and .cmake file to link against the library using:

```cmake
cmake_minimum_required(VERSION 3.14)
project(myApp LANGUAGES CXX)

set(CMAKE_CXX_STANDARD 20) # or higher
find_package(libqrcode CONFIG REQUIRED)

add_executable(${PROJECT_NAME}
    main.cpp)

target_include_directories(${PROJECT_NAME} PRIVATE ${libqrcode_INCLUDE_DIRS})
target_link_libraries(${PROJECT_NAME} PRIVATE ${libqrcode_LINK_LIBRARIES})
```